### PR TITLE
feat: git dependencies can be declared with an alias name

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "npm-run-all": "^4.0.1",
     "npm-scripts-info": "^0.3.6",
     "package-preview": "^1.0.0",
-    "pnpm-registry-mock": "^1.11.0",
+    "pnpm-registry-mock": "^1.13.0",
     "read-pkg": "^3.0.0",
     "rimraf": "^2.6.2",
     "sepia": "^2.0.2",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -76,7 +76,7 @@ devDependencies:
   npm-run-all: 4.1.2
   npm-scripts-info: 0.3.6
   package-preview: 1.0.0
-  pnpm-registry-mock: 1.11.0
+  pnpm-registry-mock: 1.13.0
   read-pkg: 3.0.0
   rimraf: 2.6.2
   sepia: 2.0.2
@@ -963,7 +963,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==
-  /cpr/2.2.0:
+  /cpr/3.0.1:
     dependencies:
       graceful-fs: 4.1.11
       minimist: 1.2.0
@@ -971,7 +971,7 @@ packages:
       rimraf: 2.6.2
     dev: true
     resolution:
-      integrity: sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==
+      integrity: sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=
   /credentials-by-uri/1.0.0:
     dependencies:
       nerf-dart: 1.0.0
@@ -3070,14 +3070,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-dB2ZeXYv362T8+Rp3rSoFNNDAAg=
-  /pnpm-registry-mock/1.11.0:
+  /pnpm-registry-mock/1.13.0:
     dependencies:
-      cpr: 2.2.0
+      cpr: 3.0.1
       rimraf: 2.6.2
       verdaccio: 2.6.6
     dev: true
     resolution:
-      integrity: sha512-BOskwTMCYLXWIwb0dHh5maoJhiarGKt9UsBkYREq2MEHkNoD2Lr9777KiJirB2Fvg0vdedogJnPKw6/k2uRriQ==
+      integrity: sha512-6TYzoAydjNvTcEX13sm9Wmp9Ke8/RT+MQTy+r7oG5gTZIFyQIXfFLqNNcb6AElDg4NftGoQLlvCW+8iWH/KJiw==
   /pnpm-shrinkwrap/5.0.0:
     dependencies:
       '@types/node': 7.0.46
@@ -4397,7 +4397,7 @@ specifiers:
   path-exists: ^3.0.0
   path-name: ^1.0.0
   pnpm-install-checks: ^1.1.0
-  pnpm-registry-mock: ^1.11.0
+  pnpm-registry-mock: ^1.13.0
   pnpm-shrinkwrap: ^5.0.0
   proper-lockfile: ^2.0.0
   ramda: ^0.25.0

--- a/src/link/resolvePeers.ts
+++ b/src/link/resolvePeers.ts
@@ -23,7 +23,7 @@ export type DependencyTreeNode = {
   fetchingFiles: Promise<PackageContentInfo>,
   resolution: Resolution,
   hardlinkedLocation: string,
-  children: string[],
+  children: {[alias: string]: string},
   // an independent package is a package that
   // has neither regular nor peer dependencies
   independent: boolean,
@@ -47,14 +47,17 @@ export type DependencyTreeNodeMap = {
 
 export default function (
   tree: TreeNodeMap,
-  rootNodeIds: string[],
+  rootNodeIdsByAlias: {[alias: string]: string},
   topPkgIds: string[],
   // only the top dependencies that were already installed
   // to avoid warnings about unresolved peer dependencies
   topParents: {name: string, version: string}[],
   independentLeaves: boolean,
   nodeModules: string
-): DependencyTreeNodeMap {
+): {
+  resolvedTree: DependencyTreeNodeMap,
+  rootAbsolutePathsByAlias: {[alias: string]: string},
+} {
   const pkgsByName = R.fromPairs(
     topParents.map((parent: {name: string, version: string}): R.KeyValuePair<string, ParentRef> => [
       parent.name,
@@ -65,11 +68,11 @@ export default function (
     ])
   )
 
-  const nodeIdToResolvedId = {}
+  const absolutePathsByNodeId = {}
   const resolvedTree: DependencyTreeNodeMap = {}
-  resolvePeersOfChildren(new Set(rootNodeIds), pkgsByName, {
+  resolvePeersOfChildren(rootNodeIdsByAlias, pkgsByName, {
     tree,
-    nodeIdToResolvedId,
+    absolutePathsByNodeId,
     resolvedTree,
     independentLeaves,
     nodeModules,
@@ -77,9 +80,18 @@ export default function (
   })
 
   R.values(resolvedTree).forEach(node => {
-    node.children = node.children.map(child => nodeIdToResolvedId[child])
+    node.children = R.keys(node.children).reduce((acc, alias) => {
+      acc[alias] = absolutePathsByNodeId[node.children[alias]]
+      return acc
+    }, {})
   })
-  return resolvedTree
+  return {
+    resolvedTree,
+    rootAbsolutePathsByAlias: R.keys(rootNodeIdsByAlias).reduce((rootAbsolutePathsByAlias, alias) => {
+      rootAbsolutePathsByAlias[alias] = absolutePathsByNodeId[rootNodeIdsByAlias[alias]]
+      return rootAbsolutePathsByAlias
+    }, {})
+  }
 }
 
 function resolvePeersOfNode (
@@ -87,52 +99,54 @@ function resolvePeersOfNode (
   parentPkgs: ParentRefs,
   ctx: {
     tree: TreeNodeMap,
-    nodeIdToResolvedId: {[nodeId: string]: string},
+    absolutePathsByNodeId: {[nodeId: string]: string},
     resolvedTree: DependencyTreeNodeMap,
     independentLeaves: boolean,
     nodeModules: string,
     purePkgs: Set<string>, // pure packages are those that don't rely on externally resolved peers
   }
-): Set<string> {
+): {[alias: string]: string} {
   const node = ctx.tree[nodeId]
   if (ctx.purePkgs.has(node.pkg.id) && ctx.resolvedTree[node.pkg.id].depth <= node.depth) {
-    ctx.nodeIdToResolvedId[nodeId] = node.pkg.id
-    return new Set()
+    ctx.absolutePathsByNodeId[nodeId] = node.pkg.id
+    return {}
   }
 
-  const childrenSet = new Set(node.children)
-  const unknownResolvedPeersOfChildren = resolvePeersOfChildren(childrenSet, parentPkgs, ctx)
+  const unknownResolvedPeersOfChildren = resolvePeersOfChildren(node.children, parentPkgs, ctx, nodeId)
 
   const resolvedPeers = R.isEmpty(node.pkg.peerDependencies)
-    ? new Set<string>()
+    ? {}
     : resolvePeers(node, Object.assign({}, parentPkgs,
-      toPkgByName(R.props<TreeNode>(node.children, ctx.tree))
+      toPkgByName(R.keys(node.children).map(alias => ({
+        alias: alias,
+        node: ctx.tree[node.children[alias]],
+      })))
     ), ctx.tree)
 
-  unknownResolvedPeersOfChildren.delete(nodeId)
-
-  const allResolvedPeers = union(
-    unknownResolvedPeersOfChildren,
-    resolvedPeers)
+  const allResolvedPeers = Object.assign({}, unknownResolvedPeersOfChildren, resolvedPeers)
 
   let modules: string
   let absolutePath: string
   const localLocation = path.join(ctx.nodeModules, `.${pkgIdToFilename(node.pkg.id)}`)
-  if (!allResolvedPeers.size) {
+  if (R.isEmpty(allResolvedPeers)) {
     modules = path.join(localLocation, 'node_modules')
     absolutePath = node.pkg.id
     if (R.isEmpty(node.pkg.peerDependencies)) {
       ctx.purePkgs.add(node.pkg.id)
     }
   } else {
-    const peersFolder = createPeersFolderName(R.props<TreeNode>(Array.from(allResolvedPeers), ctx.tree).map(node => node.pkg))
+    const peersFolder = createPeersFolderName(
+      R.keys(allResolvedPeers).map(alias => ({
+        name: alias,
+        version: ctx.tree[allResolvedPeers[alias]].pkg.version,
+      })))
     modules = path.join(localLocation, peersFolder, 'node_modules')
     absolutePath = `${node.pkg.id}/${peersFolder}`
   }
 
-  ctx.nodeIdToResolvedId[nodeId] = absolutePath
+  ctx.absolutePathsByNodeId[nodeId] = absolutePath
   if (!ctx.resolvedTree[absolutePath] || ctx.resolvedTree[absolutePath].depth > node.depth) {
-    const independent = ctx.independentLeaves && !node.children.length && R.isEmpty(node.pkg.peerDependencies)
+    const independent = ctx.independentLeaves && R.isEmpty(node.children) && R.isEmpty(node.pkg.peerDependencies)
     const pathToUnpacked = path.join(node.pkg.path, 'node_modules', node.pkg.name)
     const hardlinkedLocation = !independent
       ? path.join(modules, node.pkg.name)
@@ -148,7 +162,7 @@ function resolvePeersOfNode (
       hardlinkedLocation,
       independent,
       optionalDependencies: node.pkg.optionalDependencies,
-      children: Array.from(union(childrenSet, resolvedPeers)),
+      children: Object.assign({}, node.children, resolvedPeers),
       depth: node.depth,
       absolutePath,
       prod: node.pkg.prod,
@@ -178,28 +192,35 @@ function difference<T>(a: Set<T>, b: Set<T>) {
 }
 
 function resolvePeersOfChildren (
-  children: Set<string>,
+  children: {
+    [alias: string]: string,
+  },
   parentParentPkgs: ParentRefs,
   ctx: {
     tree: {[nodeId: string]: TreeNode},
-    nodeIdToResolvedId: {[nodeId: string]: string},
+    absolutePathsByNodeId: {[nodeId: string]: string},
     resolvedTree: DependencyTreeNodeMap,
     independentLeaves: boolean,
     nodeModules: string,
     purePkgs: Set<string>,
-  }
-): Set<string> {
-  const childrenArray = Array.from(children)
-  let allResolvedPeers = new Set()
+  },
+  exceptNodeId?: string,
+): {[alias: string]: string} {
+  let allResolvedPeers: {[alias: string]: string} = {}
   const parentPkgs = Object.assign({}, parentParentPkgs,
-    toPkgByName(R.props<TreeNode>(childrenArray, ctx.tree))
+    toPkgByName(R.keys(children).map(alias => ({alias: alias, node: ctx.tree[children[alias]]})))
   )
 
-  for (const child of childrenArray) {
-    addMany(allResolvedPeers, resolvePeersOfNode(child, parentPkgs, ctx))
+  for (const childNodeId of R.values(children)) {
+    Object.assign(allResolvedPeers, resolvePeersOfNode(childNodeId, parentPkgs, ctx))
   }
 
-  const unknownResolvedPeersOfChildren = difference(allResolvedPeers, children)
+  const unknownResolvedPeersOfChildren = R.keys(allResolvedPeers)
+    .filter(alias => !children[alias] && allResolvedPeers[alias] !== exceptNodeId)
+    .reduce((unknownResolvedPeersOfChildren, peer) => {
+      unknownResolvedPeersOfChildren[peer] = allResolvedPeers[peer]
+      return unknownResolvedPeersOfChildren
+    }, {})
 
   return unknownResolvedPeersOfChildren
 }
@@ -208,8 +229,10 @@ function resolvePeers (
   node: TreeNode,
   parentPkgs: ParentRefs,
   tree: TreeNodeMap
-): Set<string> {
-  const resolvedPeers = new Set<string>()
+): {
+  [alias: string]: string
+} {
+  const resolvedPeers: {[alias: string]: string} = {}
   for (const peerName in node.pkg.peerDependencies) {
     const peerVersionRange = node.pkg.peerDependencies[peerName]
 
@@ -239,7 +262,7 @@ function resolvePeers (
       continue
     }
 
-    if (resolved && resolved.nodeId) resolvedPeers.add(resolved.nodeId)
+    if (resolved && resolved.nodeId) resolvedPeers[peerName] = resolved.nodeId
   }
   return resolvedPeers
 }
@@ -266,18 +289,18 @@ type ParentRef = {
   nodeId?: string,
 }
 
-function toPkgByName (nodes: TreeNode[]): ParentRefs {
+function toPkgByName (nodes: {alias: string, node: TreeNode}[]): ParentRefs {
   const pkgsByName: ParentRefs = {}
   for (const node of nodes) {
-    pkgsByName[node.pkg.name] = {
-      version: node.pkg.version,
-      nodeId: node.nodeId,
-      depth: node.depth,
+    pkgsByName[node.alias] = {
+      version: node.node.pkg.version,
+      nodeId: node.node.nodeId,
+      depth: node.node.depth,
     }
   }
   return pkgsByName
 }
 
-function createPeersFolderName(peers: InstalledPackage[]) {
+function createPeersFolderName(peers: {name: string, version: string}[]) {
   return peers.map(peer => `${peer.name.replace('/', '!')}@${peer.version}`).sort().join('+')
 }

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -54,6 +54,7 @@ export type DependencyType = 'prod' | 'dev' | 'optional'
 export type RootMessage = {
   added: {
     name: string,
+    realName: string,
     version: string,
     dependencyType: DependencyType,
   },

--- a/test/install/fromRepo.ts
+++ b/test/install/fromRepo.ts
@@ -1,8 +1,14 @@
+import path = require('path')
 import tape = require('tape')
 import promisifyTape from 'tape-promise'
 import isCI = require('is-ci')
 import readPkg = require('read-pkg')
-import {installPkgs} from 'supi'
+import exists = require('path-exists')
+import sinon = require('sinon')
+import {
+  installPkgs,
+  RootLog,
+} from 'supi'
 import {
   prepare,
   testDefaults,
@@ -20,6 +26,62 @@ test('from a github repo', async function (t) {
 
   const pkgJson = await readPkg()
   t.deepEqual(pkgJson.dependencies, {'is-negative': 'github:kevva/is-negative'}, 'has been added to dependencies in package.json')
+})
+
+test('from a github repo with different name', async function (t: tape.Test) {
+  const project = prepare(t)
+
+  const reporter = sinon.spy()
+
+  await installPkgs(['say-hi@github:zkochan/hi#4cdebec76b7b9d1f6e219e06c42d92a6b8ea60cd'], testDefaults({reporter}))
+
+  const m = project.requireModule('say-hi')
+
+  t.ok(reporter.calledWithMatch(<RootLog>{
+    name: 'pnpm:root',
+    level: 'info',
+    added: {
+      name: 'say-hi',
+      realName: 'hi',
+      version: '1.0.0',
+      dependencyType: 'prod',
+    },
+  }), 'adding to root logged with real name and alias name')
+
+  t.equal(m, 'Hi', 'dep is available')
+
+  const pkgJson = await readPkg()
+  t.deepEqual(pkgJson.dependencies, {'say-hi': 'github:zkochan/hi#4cdebec76b7b9d1f6e219e06c42d92a6b8ea60cd'}, 'has been added to dependencies in package.json')
+
+  const shr = await project.loadShrinkwrap()
+  t.deepEqual(shr.dependencies, {
+    'say-hi': 'github.com/zkochan/hi/4cdebec76b7b9d1f6e219e06c42d92a6b8ea60cd',
+  }, 'the aliased name added to shrinkwrap.yaml')
+
+  await project.isExecutable('.bin/hi')
+  await project.isExecutable('.bin/szia')
+})
+
+test('a subdependency is from a github repo with different name', async function (t: tape.Test) {
+  const project = prepare(t)
+
+  await installPkgs(['has-aliased-git-dependency'], testDefaults())
+
+  const m = project.requireModule('has-aliased-git-dependency')
+
+  t.equal(m, 'Hi', 'subdep is accessible')
+
+  const shr = await project.loadShrinkwrap()
+  t.deepEqual(shr.packages['/has-aliased-git-dependency/1.0.0'].dependencies, {
+    'has-say-hi-peer': '/has-say-hi-peer/1.0.0/say-hi@1.0.0',
+    'say-hi': 'github.com/zkochan/hi/4cdebec76b7b9d1f6e219e06c42d92a6b8ea60cd',
+  }, 'the aliased name added to shrinkwrap.yaml')
+
+  await project.isExecutable('has-aliased-git-dependency/node_modules/.bin/hi')
+  await project.isExecutable('has-aliased-git-dependency/node_modules/.bin/szia')
+
+  t.ok(await exists(path.join('node_modules', '.localhost+4873', 'has-say-hi-peer', '1.0.0', 'say-hi@1.0.0', 'node_modules', 'has-say-hi-peer')),
+    'aliased name used to resolve a peer dependency')
 })
 
 test('from a git repo', async function (t) {

--- a/test/install/local.ts
+++ b/test/install/local.ts
@@ -48,7 +48,7 @@ test('local file', async function (t: tape.Test) {
     },
     registry: 'http://localhost:4873/',
     shrinkwrapVersion: 3,
-    shrinkwrapMinorVersion: 2,
+    shrinkwrapMinorVersion: 3,
   })
 })
 

--- a/test/install/misc.ts
+++ b/test/install/misc.ts
@@ -78,6 +78,7 @@ test('no dependencies (lodash)', async (t: tape.Test) => {
     level: 'info',
     added: {
       name: 'lodash',
+      realName: 'lodash',
       version: '4.0.0',
       dependencyType: 'prod',
       latest: '4.1.0',

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -491,7 +491,7 @@ test('scoped module from different registry', async function (t: tape.Test) {
       'is-positive': '^3.1.0',
     },
     shrinkwrapVersion: 3,
-    shrinkwrapMinorVersion: 2,
+    shrinkwrapMinorVersion: 3,
   })
 })
 
@@ -540,7 +540,7 @@ test['skip']('installing from shrinkwrap when using npm enterprise', async (t: t
       'is-positive': '^3.1.0',
     },
     shrinkwrapVersion: 3,
-    shrinkwrapMinorVersion: 2,
+    shrinkwrapMinorVersion: 3,
   })
 
   await rimraf(opts.store)
@@ -667,6 +667,6 @@ test('updating shrinkwrap version 3 to 3.1', async (t: tape.Test) => {
 
   const shr = await project.loadShrinkwrap()
 
-  t.equal(shr.shrinkwrapMinorVersion, 2)
+  t.equal(shr.shrinkwrapMinorVersion, 3)
   t.ok(shr.packages['/abc/1.0.0/peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0'].peerDependencies)
 })


### PR DESCRIPTION
ref https://github.com/pnpm/pnpm/issues/838

cc @vjpr

TODO:
- ~~the default bin should be renamed to the alias name~~
- [x] write a test that verifies installation of aliased dependencies in subdependencies
- [x] write a test that verifies: when peer dependencies are resolved, the aliased names are used, not the real names
- [ ] decide how `pnpm list` and other commands should behave with aliased dependencies
- [x] log needed info to print real name in summary
- ~~what about other, non-default bins? should they be prefixed or something like that?~~
- ~~update `npm-package-arg` to parse aliases for npm-hosted packages~~ will be done separately