### PR TITLE
feat: allow to ignore files in packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Install packages.
 * `options.saveExact` - *Boolean* - saved dependencies will be configured with an exact version rather than using npm's default semver range operator.
 * `options.global` - *Boolean* - the packages will be installed globally rather than locally.
 * `options.prefix` - *String* - the directory in which the installation will be performed. By default the `process.cwd()` value is used.
-* `options.quiet` - *Boolean* - `false` by default. No output to the console.
 * `options.metaCache` - *Map* - a cache for package meta info.
 * `options.networkConcurrency` - *Number* - `16` by default. Max amount of network requests to perform concurrently.
 * `options.offline` - *Boolean* - `false` by default. Install packages using only the local registry mirror, w/o doing any network requests.
 * `options.reporter` - *Function* - A function that listens for logs.
 * `options.packageManager` - *Object* - The `package.json` of the package manager.
 * `options.hooks` - *Object* - A property that contains installation hooks. Hooks are [documented separately](#hooks).
+* `options.ignoreFile` - *Function & (filename: string) => boolean* - A function that decides which files in a package are ignored. For instance,
+  there's no need in `.travis.yml` files in production, so you can set `{ignoreFile: fn => fn === '.travis.yml'}`.
 
 **Returns:** a Promise
 
@@ -53,10 +54,10 @@ Install packages.
 ```js
 const pnpm = require('pnpm')
 
-pnpm.install({
+pnpm.installPkgs({
   'is-positive': '1.0.0',
   'hello-world': '^2.3.1'
-}, { save: true, quiet: true })
+}, { saveDev: true })
 ```
 
 ### `supi.install([options])`

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "p-filter": "^1.0.0",
     "p-limit": "^1.1.0",
     "p-series": "^1.0.0",
-    "package-store": "^0.5.2",
+    "package-store": "^0.5.5",
     "path-absolute": "^1.0.0",
     "path-exists": "^3.0.0",
     "path-name": "^1.0.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -42,7 +42,7 @@ dependencies:
   p-filter: 1.0.0
   p-limit: 1.1.0
   p-series: 1.0.0
-  package-store: 0.5.2
+  package-store: 0.5.5
   path-absolute: 1.0.0
   path-exists: 3.0.0
   path-name: 1.0.0
@@ -257,6 +257,10 @@ packages:
   /@types/node/8.0.51:
     resolution:
       integrity: sha512-El3+WJk2D/ppWNd2X05aiP5l2k4EwF7KwheknQZls+I26eSICoWRhRIJ56jGgw2dqNGQ5LtNajmBU2ajS28EvQ==
+  /@types/node/8.0.53:
+    dev: false
+    resolution:
+      integrity: sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==
   /@types/nopt/3.0.29:
     dev: false
     resolution:
@@ -2866,7 +2870,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-OQbpubrdUPz5xJa98eri+Gf7zfhoLbtQACh4myRaUrCHPYzCrKvw+07v3DrV/n1aRv0/yibWkqSGC/v03ijUug==
-  /package-store/0.5.2:
+  /package-store/0.5.5:
     dependencies:
       '@pnpm/types': 1.0.0
       '@types/load-json-file': 2.0.7
@@ -2901,7 +2905,7 @@ packages:
       ssri: 5.0.0
       symlink-dir: 1.1.0
       thenify: 3.3.0
-      unpack-stream: 2.1.1
+      unpack-stream: 2.2.0
       write-json-file: 2.3.0
     dev: false
     engines:
@@ -2909,7 +2913,7 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^1.0.0
     resolution:
-      integrity: sha512-66mi8Jf87G3f+rIAYXAFgDKlRmBMPUyuyVcfKwOA6IcXXr40tKqCz7xsSui2u25JsSJaipRIbyTejVG0TPjBeA==
+      integrity: sha512-Bw8a7b1259G8NxIyj/GAlGX5OXJHsGmHRSCXND4z6CGEMIxLgSGHh8zzUm0pLfI6CraT6NBa2mgDIza6+bcS/Q==
   /pako/0.2.9:
     resolution:
       integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
@@ -3180,13 +3184,20 @@ packages:
     dependencies:
       end-of-stream: 1.4.0
       once: 1.4.0
+    optional: true
     resolution:
       integrity: sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=
+  /pump/1.0.3:
+    dependencies:
+      end-of-stream: 1.4.0
+      once: 1.4.0
+    resolution:
+      integrity: sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==
   /pumpify/1.3.5:
     dependencies:
       duplexify: 3.5.1
       inherits: 2.0.3
-      pump: 1.0.2
+      pump: 1.0.3
     resolution:
       integrity: sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=
   /punycode/1.4.1:
@@ -3850,11 +3861,11 @@ packages:
     dependencies:
       chownr: 1.0.1
       mkdirp: 0.5.1
-      pump: 1.0.2
-      tar-stream: 1.5.4
+      pump: 1.0.3
+      tar-stream: 1.5.5
     resolution:
       integrity: sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==
-  /tar-stream/1.5.4:
+  /tar-stream/1.5.5:
     dependencies:
       bl: 1.2.1
       end-of-stream: 1.4.0
@@ -3863,7 +3874,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-NlSc8E7RrumyowwBQyUiONr5QBY=
+      integrity: sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==
   /tar/2.2.1:
     dependencies:
       block-stream: 0.0.9
@@ -4080,10 +4091,22 @@ packages:
       decompress-maybe: 1.0.0
       ssri: 4.1.6
       tar-fs: 1.16.0
+    dev: true
     engines:
       node: '>=4'
     resolution:
       integrity: sha1-FXMzqT/KD6ABYGrqCpKYQy2q7nM=
+  /unpack-stream/2.2.0:
+    dependencies:
+      '@types/node': 8.0.53
+      decompress-maybe: 1.0.0
+      ssri: 5.0.0
+      tar-fs: 1.16.0
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-UU/97pTZMXBpWGRJLmmDq2mN3v3dBbFgrUNH26UpfvyVwbO1i0ZZnzQvm7YEoTcMJpFpuX9LWGYNu2rmh6K4Jg==
   /unpipe/1.0.0:
     dev: true
     engines:
@@ -4401,7 +4424,7 @@ specifiers:
   p-limit: ^1.1.0
   p-series: ^1.0.0
   package-preview: ^1.0.0
-  package-store: ^0.5.2
+  package-store: ^0.5.5
   path-absolute: ^1.0.0
   path-exists: ^3.0.0
   path-name: ^1.0.0

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -413,6 +413,7 @@ async function installInContext (
     currentDepth: 0,
     readPackageHook: opts.hooks.readPackage,
     hasManifestInShrinkwrap,
+    ignoreFile: opts.ignoreFile,
   }
   const nonLinkedPkgs = await pFilter(packagesToInstall,
     async (spec: PackageSpec) => {

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -88,6 +88,7 @@ export default async function installMultiple (
     update: boolean,
     readPackageHook?: ReadPackageHook,
     hasManifestInShrinkwrap: boolean,
+    ignoreFile?: (filename: string) => boolean,
   }
 ): Promise<PkgAddress[]> {
   const resolvedDependencies = options.resolvedDependencies || {}
@@ -119,6 +120,7 @@ export default async function installMultiple (
               parentIsInstallable: options.parentIsInstallable,
               readPackageHook: options.readPackageHook,
               hasManifestInShrinkwrap: options.hasManifestInShrinkwrap,
+              ignoreFile: options.ignoreFile,
               update,
               proceed,
             },
@@ -232,6 +234,7 @@ async function install (
     proceed: boolean,
     readPackageHook?: ReadPackageHook,
     hasManifestInShrinkwrap: boolean,
+    ignoreFile?: (filename: string) => boolean,
   }
 ): Promise<PkgAddress | null> {
   const keypath = options.keypath || []
@@ -277,6 +280,7 @@ async function install (
     storeIndex: ctx.storeIndex,
     verifyStoreIntegrity: ctx.verifyStoreInegrity,
     downloadPriority: -options.currentDepth,
+    ignore: options.ignoreFile,
   })
 
   if (fetchedPkg.isLocal) {
@@ -419,6 +423,7 @@ async function install (
         readPackageHook: options.readPackageHook,
         hasManifestInShrinkwrap: options.hasManifestInShrinkwrap,
         useManifestInfoFromShrinkwrap,
+        ignoreFile: options.ignoreFile,
       }
     )
     ctx.childrenByParentId[fetchedPkg.id] = children.map(child => ({
@@ -496,6 +501,7 @@ async function installDependencies (
     readPackageHook?: ReadPackageHook,
     hasManifestInShrinkwrap: boolean,
     useManifestInfoFromShrinkwrap: boolean,
+    ignoreFile?: (filename: string) => boolean,
   }
 ): Promise<PkgAddress[]> {
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,8 @@ export type PnpmOptions = {
   hooks?: {
     readPackage?: ReadPackageHook,
   },
+
+  ignoreFile?: (filename: string) => boolean,
 }
 
 export type ReadPackageHook = (pkg: PackageManifest) => PackageManifest

--- a/test/install/misc.ts
+++ b/test/install/misc.ts
@@ -46,6 +46,16 @@ test('small with dependencies (rimraf)', async (t: tape.Test) => {
   await project.isExecutable('.bin/rimraf')
 })
 
+test('ignoring some files in the dependency', async (t: tape.Test) => {
+  const project = prepare(t)
+
+  const ignoreFile = (filename: string) => filename === 'readme.md'
+  await installPkgs(['is-positive@1.0.0'], testDefaults({ignoreFile}))
+
+  t.ok(await exists(path.resolve('node_modules', 'is-positive', 'package.json')), 'package.json was not ignored')
+  t.notOk(await exists(path.resolve('node_modules', 'is-positive', 'readme.md')), 'readme.md was ignored')
+})
+
 test('no dependencies (lodash)', async (t: tape.Test) => {
   const project = prepare(t)
   const reporter = sinon.spy()


### PR DESCRIPTION
The opts.ignoreFile() function allows to ignore files in packages.
Ignoring means that files will neither be unpacked nor linked
into `node_modules`

Ref https://github.com/pnpm/pnpm/issues/804