### PR TITLE
fix: too long folder names in node_modules

### DIFF
--- a/test/install/peerDependencies.ts
+++ b/test/install/peerDependencies.ts
@@ -123,7 +123,7 @@ test('peer dependencies are linked when running one named installation', async (
 
   const pkgVariationsDir = path.join(NM, '.localhost+4873', 'abc', '1.0.0')
 
-  const pkgVariation1 = path.join(pkgVariationsDir, 'peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0', NM)
+  const pkgVariation1 = path.join(pkgVariationsDir, '165e1e08a3f7e7f77ddb572ad0e55660', NM)
   await okFile(t, path.join(pkgVariation1, 'abc'))
   await okFile(t, path.join(pkgVariation1, 'peer-a'))
   await okFile(t, path.join(pkgVariation1, 'peer-b'))
@@ -147,7 +147,7 @@ test('peer dependencies are linked when running two separate named installations
 
   const pkgVariationsDir = path.join(NM, '.localhost+4873', 'abc', '1.0.0')
 
-  const pkgVariation1 = path.join(pkgVariationsDir, 'peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0', NM)
+  const pkgVariation1 = path.join(pkgVariationsDir, '165e1e08a3f7e7f77ddb572ad0e55660', NM)
   await okFile(t, path.join(pkgVariation1, 'abc'))
   await okFile(t, path.join(pkgVariation1, 'peer-a'))
   await okFile(t, path.join(pkgVariation1, 'peer-b'))
@@ -178,7 +178,7 @@ test['skip']('peer dependencies are linked', async (t: tape.Test) => {
 
   const pkgVariationsDir = path.join(NM, '.localhost+4873', 'abc', '1.0.0')
 
-  const pkgVariation1 = path.join(pkgVariationsDir, 'peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0', NM)
+  const pkgVariation1 = path.join(pkgVariationsDir, '165e1e08a3f7e7f77ddb572ad0e55660', NM)
   await okFile(t, path.join(pkgVariation1, 'abc'))
   await okFile(t, path.join(pkgVariation1, 'peer-a'))
   await okFile(t, path.join(pkgVariation1, 'peer-b'))

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -631,13 +631,13 @@ test('updating shrinkwrap version 3 to 3.1', async (t: tape.Test) => {
           integrity: sha512-/sPoyuCaOuJAG6Gcq7HxiW8/++Jj3zmzfymr+mKbNG8VftROlRAd1qoOtA37xNJXYNRT2Zwb0Gym2fdt/eXKaQ==
       /abc-parent-with-ab/1.0.0/peer-c@1.0.0:
         dependencies:
-          abc: /abc/1.0.0/peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0
+          abc: /abc/1.0.0/165e1e08a3f7e7f77ddb572ad0e55660
           peer-a: 1.0.0
           peer-b: 1.0.0
         id: localhost+4873/abc-parent-with-ab/1.0.0
         resolution:
           integrity: sha512-8ULNWX/kq0K8zdbLdN9rjxJIVaqihDJbTTJSeH8cfz0rXleV2RxBhKJ9kqjk/kmplpHJEDyhLKDjubWlS10WUA==
-      /abc/1.0.0/peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0:
+      /abc/1.0.0/165e1e08a3f7e7f77ddb572ad0e55660:
         dependencies:
           dep-of-pkg-with-1-dep: 100.0.0
           peer-a: 1.0.0
@@ -671,7 +671,7 @@ test('updating shrinkwrap version 3 to 3.1', async (t: tape.Test) => {
   const shr = await project.loadShrinkwrap()
 
   t.equal(shr.shrinkwrapMinorVersion, 4)
-  t.ok(shr.packages['/abc/1.0.0/peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0'].peerDependencies)
+  t.ok(shr.packages['/abc/1.0.0/165e1e08a3f7e7f77ddb572ad0e55660'].peerDependencies)
 })
 
 test('pendingBuilds gets updated if install removes packages', async (t: tape.Test) => {


### PR DESCRIPTION
If a package has many peer dependencies, it can be placed in a
folder with a very long name. This change hashes folder names
that are longer than 32 symbols.

SEMI-BREAKING:

The structure of node_modules might change in some projects after
a clean install.

ref https://github.com/pnpm/pnpm/issues/977