### PR TITLE
fix: flatten peer dependencies correctly

### DIFF
--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -186,8 +186,8 @@ async function shamefullyFlattenTree(
     outdatedPkgs: {[pkgId: string]: string},
   },
 ): Promise<{[alias: string]: string[]}> {
-  const pkgIdByAlias = {}
-  const aliasByPkgId: {[pkgId: string]: string[]} = {}
+  const pkgPathByAlias = {}
+  const aliasesByPkgPath: {[pkgId: string]: string[]} = {}
 
   await Promise.all(flatResolvedDeps
     // sort by depth and then alphabetically
@@ -203,20 +203,20 @@ async function shamefullyFlattenTree(
           continue
         }
         // if this alias has already been taken, skip it
-        if (pkgIdByAlias[childAlias]) {
+        if (pkgPathByAlias[childAlias]) {
           continue
         }
-        const childId = pkg.children[childAlias]
-        pkgIdByAlias[childAlias] = childId
-        if (!aliasByPkgId[childId]) {
-          aliasByPkgId[childId] = []
+        const childPath = pkg.children[childAlias]
+        pkgPathByAlias[childAlias] = childPath
+        if (!aliasesByPkgPath[childPath]) {
+          aliasesByPkgPath[childPath] = []
         }
-        aliasByPkgId[childId].push(childAlias)
+        aliasesByPkgPath[childPath].push(childAlias)
       }
       return pkg
     })
     .map(async pkg => {
-      const pkgAliases = aliasByPkgId[pkg.id]
+      const pkgAliases = aliasesByPkgPath[pkg.absolutePath]
       if (!pkgAliases) {
         return
       }
@@ -229,7 +229,7 @@ async function shamefullyFlattenTree(
       }
     }))
 
-  return aliasByPkgId
+  return aliasesByPkgPath
 }
 
 function filterShrinkwrap (

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -186,8 +186,8 @@ async function shamefullyFlattenTree(
     outdatedPkgs: {[pkgId: string]: string},
   },
 ): Promise<{[alias: string]: string[]}> {
-  const pkgPathByAlias = {}
-  const aliasesByPkgPath: {[pkgId: string]: string[]} = {}
+  const dependencyPathByAlias = {}
+  const aliasesByDependencyPath: {[pkgId: string]: string[]} = {}
 
   await Promise.all(flatResolvedDeps
     // sort by depth and then alphabetically
@@ -203,20 +203,20 @@ async function shamefullyFlattenTree(
           continue
         }
         // if this alias has already been taken, skip it
-        if (pkgPathByAlias[childAlias]) {
+        if (dependencyPathByAlias[childAlias]) {
           continue
         }
         const childPath = pkg.children[childAlias]
-        pkgPathByAlias[childAlias] = childPath
-        if (!aliasesByPkgPath[childPath]) {
-          aliasesByPkgPath[childPath] = []
+        dependencyPathByAlias[childAlias] = childPath
+        if (!aliasesByDependencyPath[childPath]) {
+          aliasesByDependencyPath[childPath] = []
         }
-        aliasesByPkgPath[childPath].push(childAlias)
+        aliasesByDependencyPath[childPath].push(childAlias)
       }
       return pkg
     })
     .map(async pkg => {
-      const pkgAliases = aliasesByPkgPath[pkg.absolutePath]
+      const pkgAliases = aliasesByDependencyPath[pkg.absolutePath]
       if (!pkgAliases) {
         return
       }
@@ -229,7 +229,7 @@ async function shamefullyFlattenTree(
       }
     }))
 
-  return aliasesByPkgPath
+  return aliasesByDependencyPath
 }
 
 function filterShrinkwrap (

--- a/test/install/shamefullyFlatten.ts
+++ b/test/install/shamefullyFlatten.ts
@@ -198,3 +198,10 @@ test('should reflatten after pruning', async function (t) {
 
   await project.hasNot('is-positive')
 })
+
+test('should flatten correctly peer dependencies', async function (t) {
+  const project = prepare(t)
+  await installPkgs(['using-ajv'], await testDefaults({shamefullyFlatten: true}))
+
+  await project.has('ajv-keywords')
+})


### PR DESCRIPTION
This flattens peer dependencies correctly, because children contains absolutePaths, not ids