### PR TITLE
feat: specify linked deps in shrinkwrap.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Uninstalls a package, completely removing everything pnpm installed on its behal
 * `options.global` - *Boolean* - the packages will be uninstalled globally.
 * `options.reporter` - *Function* - A function that listens for logs.
 
-### `supi.link(linkFrom, linkToNodeModules, [options])`
+### `supi.link(linkFromPkgs, linkToNodeModules, [options])`
 
-Create a symbolic link from the linked package to the target package's `node_modules` (and its `node_modules/.bin`).
+Create symbolic links from the linked packages to the target package's `node_modules` (and its `node_modules/.bin`).
 
 **Arguments:**
 
-* `linkFrom` - *String* - path to the package that should be linked.
+* `linkFromPkgs` - *String[]* - paths to the packages that should be linked.
 * `linkToNodeModules` - *String* - path to the dependent package's `node_modules` directory.
 * `options.reporter` - *Function* - A function that listens for logs.
 
@@ -103,13 +103,13 @@ Create a symbolic link from the specified package to the global `node_modules`.
 * `globalPrefix` - *String* - path to the global directory.
 * `options.reporter` - *Function* - A function that listens for logs.
 
-### `supi.linkFromGlobal(pkgName, linkTo, options)`
+### `supi.linkFromGlobal(pkgNames, linkTo, options)`
 
-Create a symbolic link from the global `pkgName` to the `linkTo/node_modules` folder.
+Create symbolic links from the global `pkgName`s to the `linkTo/node_modules` folder.
 
 **Arguments:**
 
-* `pkgName` - *String* - package to link.
+* `pkgNames` - *String[]* - packages to link.
 * `linkTo` - *String* - package to link to.
 * `globalPrefix` - *String* - path to the global directory.
 * `options.reporter` - *Function* - A function that listens for logs.

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "path-exists": "^3.0.0",
     "path-name": "^1.0.0",
     "pnpm-install-checks": "^1.1.0",
-    "pnpm-shrinkwrap": "^5.3.0",
+    "pnpm-shrinkwrap": "^6.0.0",
     "ramda": "^0.25.0",
     "read-package-json": "^2.0.5",
     "remove-all-except-outer-links": "^1.0.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -48,7 +48,7 @@ dependencies:
   path-exists: 3.0.0
   path-name: 1.0.0
   pnpm-install-checks: 1.1.0
-  pnpm-shrinkwrap: 5.3.0
+  pnpm-shrinkwrap: 6.0.0
   ramda: 0.25.0
   read-package-json: 2.0.12
   remove-all-except-outer-links: 1.0.3
@@ -204,7 +204,7 @@ packages:
   /@pnpm/default-resolver/0.1.4:
     dependencies:
       '@pnpm/git-resolver': 0.3.1
-      '@pnpm/local-resolver': 0.2.0
+      '@pnpm/local-resolver': 0.2.2
       '@pnpm/npm-resolver': 0.3.13
       '@pnpm/tarball-resolver': 0.1.0
     dev: true
@@ -267,7 +267,7 @@ packages:
       '@pnpm/logger': ^1.0.0
     resolution:
       integrity: sha512-V6oKCFxi8+3jVoVoZ216KOEBaf+S5a6bajOj0iHLfnVE0u1G9SA7j0TDNx1IWD26+LTA0EUIKCPmmgrRVlpt1g==
-  /@pnpm/local-resolver/0.2.0:
+  /@pnpm/local-resolver/0.2.2:
     dependencies:
       '@pnpm/types': 1.7.0
       '@types/graceful-fs': 4.1.2
@@ -282,7 +282,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-z2JAaG1lzvQ1ykmPfbKpipw46/u4r6TI3nFQK+XMIKIt7Or0xT13D4OMKOKJpNIqj3MalrNmXVXZ3uN8um+Rrg==
+      integrity: sha512-tAGRiCX8EjMj2sJuiJlWncv1N8CUSoYmmfgJIoWu2q3uMdBvkY4/K5sCjghjGnB9mEmb1inObRyOwBOKrlBOlA==
   /@pnpm/logger/1.0.1:
     dependencies:
       '@types/node': 9.4.6
@@ -732,7 +732,7 @@ packages:
   /are-we-there-yet/1.1.4:
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     resolution:
       integrity: sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=
   /argparse/1.0.10:
@@ -856,7 +856,7 @@ packages:
       integrity: sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
   /bl/1.2.1:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: true
     resolution:
       integrity: sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=
@@ -1211,7 +1211,7 @@ packages:
   /concat-stream/1.6.1:
     dependencies:
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       typedarray: 0.0.6
     dev: true
     engines:
@@ -1554,7 +1554,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.1
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       stream-shift: 1.0.0
     dev: true
     resolution:
@@ -1853,7 +1853,7 @@ packages:
   /flush-write-stream/1.0.2:
     dependencies:
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: true
     resolution:
       integrity: sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=
@@ -1897,7 +1897,7 @@ packages:
   /from2/2.3.0:
     dependencies:
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: true
     resolution:
       integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -1914,7 +1914,7 @@ packages:
       graceful-fs: 4.1.11
       iferr: 0.1.5
       imurmurhash: 0.1.4
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: true
     resolution:
       integrity: sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=
@@ -2208,13 +2208,15 @@ packages:
       npm: '>=1.3.7'
     resolution:
       integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
-  /https-proxy-agent/2.1.1:
+  /https-proxy-agent/2.2.0:
     dependencies:
       agent-base: 4.2.0
       debug: 3.1.0
     dev: true
+    engines:
+      node: '>= 4.5.0'
     resolution:
-      integrity: sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==
+      integrity: sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==
   /humanize-ms/1.2.1:
     dependencies:
       ms: 2.1.1
@@ -2781,7 +2783,7 @@ packages:
       cacache: 10.0.4
       http-cache-semantics: 3.8.1
       http-proxy-agent: 2.0.0
-      https-proxy-agent: 2.1.1
+      https-proxy-agent: 2.2.0
       lru-cache: 4.1.1
       mississippi: 1.3.1
       node-fetch-npm: 2.0.2
@@ -3483,7 +3485,7 @@ packages:
     dependencies:
       cyclist: 0.2.2
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: true
     resolution:
       integrity: sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=
@@ -3671,7 +3673,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PijlGxk564x1E/3Pw0hzcE6tw9Va/lZ/UVfheq+ld62c8mqOmgC/49DCx+YIV1RAwscDttsVUT3EeAjAZHh55g==
-  /pnpm-shrinkwrap/5.3.0:
+  /pnpm-shrinkwrap/6.0.0:
     dependencies:
       '@types/node': 9.4.6
       '@types/ramda': 0.25.19
@@ -3689,7 +3691,7 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^1.0.0
     resolution:
-      integrity: sha512-WdBYsVsaRbKLnU7Vb7QAk2SE9UAD0j0AaWcv5VTX1ky2bJWqF1JE5NJSpedyL/rTr3eBNQiqM5nzV+WbzX0mUQ==
+      integrity: sha512-c+GWM0deEHpp5nb2RG6FXyl2jX04lwiOAG14+hMhtYg6BwyDqdK9gURIxCwcgXZFifj2X5rze+6eOAYUSkghtQ==
   /prepend-http/2.0.0:
     dev: true
     engines:
@@ -3877,7 +3879,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  /readable-stream/2.3.4:
+  /readable-stream/2.3.5:
     dependencies:
       core-util-is: 1.0.2
       inherits: 2.0.3
@@ -3887,7 +3889,7 @@ packages:
       string_decoder: 1.0.3
       util-deprecate: 1.0.2
     resolution:
-      integrity: sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==
+      integrity: sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==
   /readline2/1.0.1:
     dependencies:
       code-point-at: 1.1.0
@@ -4522,7 +4524,7 @@ packages:
     dependencies:
       bl: 1.2.1
       end-of-stream: 1.4.1
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       xtend: 4.0.1
     dev: true
     engines:
@@ -4569,7 +4571,7 @@ packages:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
   /through2/2.0.3:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       xtend: 4.0.1
     dev: true
     resolution:
@@ -4662,7 +4664,7 @@ packages:
       resolve: 1.5.0
       semver: 5.5.0
       tslib: 1.9.0
-      tsutils: 2.22.0
+      tsutils: 2.22.1
     dev: true
     engines:
       node: '>=4.8.0'
@@ -4670,14 +4672,14 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
-  /tsutils/2.22.0:
+  /tsutils/2.22.1:
     dependencies:
       tslib: 1.9.0
     dev: true
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
     resolution:
-      integrity: sha512-05iMIQXsLVBx2vPTvpsHriRuNpKpU1Z9jqYUOBvwglO6I+QzdA1UQcVoNhsVkSZfns5TjFMFbdxdrkOW6cfwUQ==
+      integrity: sha512-j4Nx7aeMPyIrKtDftSfDiTFBYW3o/41T3zAxm0C/9fSKT62jnfqOZooC9uKLr4rQF9QsZaVTVY6QY+vVnWSisw==
   /tunnel-agent/0.6.0:
     dependencies:
       safe-buffer: 5.1.1
@@ -5114,7 +5116,7 @@ specifiers:
   path-name: ^1.0.0
   pnpm-install-checks: ^1.1.0
   pnpm-registry-mock: ^1.17.0
-  pnpm-shrinkwrap: ^5.3.0
+  pnpm-shrinkwrap: ^6.0.0
   ramda: ^0.25.0
   read-package-json: ^2.0.5
   read-pkg: ^3.0.0

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -168,7 +168,9 @@ export async function install (maybeOpts: InstallOptions) {
       ctx.wantedShrinkwrap.optionalDependencies = ctx.wantedShrinkwrap.optionalDependencies || {}
       for (const spec of specs) {
         if (spec.alias && ctx.wantedShrinkwrap.specifiers[spec.alias] !== spec.pref) {
-          delete ctx.wantedShrinkwrap.dependencies[spec.alias]
+          if (ctx.wantedShrinkwrap.dependencies[spec.alias] && !ctx.wantedShrinkwrap.dependencies[spec.alias].startsWith('link:')) {
+            delete ctx.wantedShrinkwrap.dependencies[spec.alias]
+          }
           delete ctx.wantedShrinkwrap.devDependencies[spec.alias]
           delete ctx.wantedShrinkwrap.optionalDependencies[spec.alias]
         }

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -629,13 +629,14 @@ async function installInContext (
         skipInstall: true,
         linkToBin: opts.bin,
       }
-      await Promise.all(installCtx.localPackages.map(async localPackage => {
-        await externalLink(localPackage.resolution.directory, installCtx.nodeModules, linkOpts)
+      const externalPkgs = installCtx.localPackages.map(localPackage => localPackage.resolution.directory)
+      await externalLink(externalPkgs, installCtx.nodeModules, linkOpts)
+      installCtx.localPackages.forEach(async localPackage => {
         logStatus({
           status: 'installed',
           pkgId: localPackage.id,
         })
-      }))
+      })
     }
   }
 

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -6,12 +6,13 @@ import {PackageJson} from '@pnpm/types'
 import {install} from './install'
 import pathAbsolute = require('path-absolute')
 import normalize = require('normalize-path')
+import R = require('ramda')
 import {linkPkgBins} from '../link/linkBins'
 import extendOptions, {
   InstallOptions,
 } from './extendInstallOptions'
 import readShrinkwrapFile from '../readShrinkwrapFiles'
-import {prune as pruneNodeModules} from './prune'
+import removeOrphanPkgs from './removeOrphanPkgs'
 import pLimit = require('p-limit')
 import {
   Shrinkwrap,
@@ -21,6 +22,9 @@ import {
 } from 'pnpm-shrinkwrap'
 import readPackage from '../fs/readPkg'
 import getSpecFromPackageJson from '../getSpecFromPackageJson'
+import {
+  read as readModules,
+} from '../fs/modulesController'
 
 const linkLogger = logger('link')
 const installLimit = pLimit(4)
@@ -57,7 +61,9 @@ export default async function link (
     force: opts.force,
     registry: opts.registry,
   })
+  const oldShrinkwrap = R.clone(shrFiles.currentShrinkwrap)
   const pkg = await readPackage(path.join(opts.prefix, 'package.json'))
+  const linkedPkgs: {path: string, pkg: PackageJson}[] = []
 
   for (const linkFrom of linkFromPkgs) {
     const linkedPkg = await loadJsonFile(path.join(linkFrom, 'package.json'))
@@ -71,14 +77,31 @@ export default async function link (
     addLinkToShrinkwrap(shrFiles.currentShrinkwrap, addLinkOpts)
     addLinkToShrinkwrap(shrFiles.wantedShrinkwrap, addLinkOpts)
 
-    await linkToModules(linkedPkg.name, linkFrom, destModules)
-
-    const linkToBin = maybeOpts && maybeOpts.linkToBin || path.join(destModules, '.bin')
-    await linkPkgBins(linkFrom, linkToBin)
+    linkedPkgs.push({path: linkFrom, pkg: linkedPkg})
   }
 
   const updatedCurrentShrinkwrap = pruneShrinkwrap(shrFiles.currentShrinkwrap)
   const updatedWantedShrinkwrap = pruneShrinkwrap(shrFiles.wantedShrinkwrap)
+  const modulesInfo = await readModules(destModules)
+  await removeOrphanPkgs({
+    oldShrinkwrap,
+    newShrinkwrap: updatedCurrentShrinkwrap,
+    bin: opts.bin,
+    prefix: opts.prefix,
+    shamefullyFlatten: opts.shamefullyFlatten,
+    storeController: opts.storeController,
+    hoistedAliases: modulesInfo && modulesInfo.hoistedAliases || {},
+  })
+
+  // Linking should happen after removing orphans
+  // Otherwise would've been removed
+  for (const linkedPkg of linkedPkgs) {
+    await linkToModules(linkedPkg.pkg.name, linkedPkg.path, destModules)
+
+    const linkToBin = maybeOpts && maybeOpts.linkToBin || path.join(destModules, '.bin')
+    await linkPkgBins(linkedPkg.path, linkToBin)
+  }
+
   if (opts.shrinkwrap) {
     await saveShrinkwrap(opts.prefix, updatedWantedShrinkwrap, updatedCurrentShrinkwrap)
   } else {
@@ -88,11 +111,6 @@ export default async function link (
   if (reporter) {
     streamParser.removeListener('data', reporter)
   }
-
-  // TODO: call an internal implementation maybe, so that there would be no need to
-  // unattach and attach reporter again
-  // TODO: cover pruning after linking with tests
-  await pruneNodeModules(opts)
 }
 
 function addLinkToShrinkwrap (

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -10,9 +10,10 @@ import extendOptions, {
   InstallOptions,
 } from './extendInstallOptions'
 import readShrinkwrapFile from '../readShrinkwrapFiles'
+import {prune as pruneNodeModules} from './prune'
 import {
   Shrinkwrap,
-  prune,
+  prune as pruneShrinkwrap,
   write as saveShrinkwrap,
   writeCurrentOnly as saveCurrentShrinkwrapOnly,
 } from 'pnpm-shrinkwrap'
@@ -65,6 +66,11 @@ export default async function link (
   if (reporter) {
     streamParser.removeListener('data', reporter)
   }
+
+  // TODO: call an internal implementation maybe, so that there would be no need to
+  // unattach and attach reporter again
+  // TODO: cover pruning after linking with tests
+  await pruneNodeModules(opts)
 }
 
 function addLinkToShrinkwrap (shr: Shrinkwrap, prefix: string, linkFrom: string, linkedPkgName: string) {
@@ -83,7 +89,7 @@ function addLinkToShrinkwrap (shr: Shrinkwrap, prefix: string, linkFrom: string,
     shr.dependencies = shr.dependencies || {}
     shr.dependencies[linkedPkgName] = id
   }
-  return prune(shr)
+  return pruneShrinkwrap(shr)
 }
 
 async function linkToModules (pkgName: string, linkFrom: string, modules: string) {

--- a/src/getSpecFromPackageJson.ts
+++ b/src/getSpecFromPackageJson.ts
@@ -1,0 +1,7 @@
+import {PackageJson} from '@pnpm/types'
+
+export default (pkg: PackageJson, depName: string) => {
+  return pkg.dependencies && pkg.dependencies[depName]
+    || pkg.devDependencies && pkg.devDependencies[depName]
+    || pkg.optionalDependencies && pkg.optionalDependencies[depName]
+}

--- a/test/link.ts
+++ b/test/link.ts
@@ -21,6 +21,7 @@ import {
   RootLog,
 } from 'supi'
 import exists = require('path-exists')
+import writeJsonFile = require('write-json-file')
 
 test('relative link', async (t: tape.Test) => {
   const project = prepare(t, {
@@ -120,4 +121,18 @@ test('failed linking should not create empty folder', async (t: tape.Test) => {
   } catch (err) {
     t.notOk(await exists(path.join(globalPrefix, 'node_modules', 'does-not-exist')))
   }
+})
+
+test('node_modules is pruned after linking', async (t: tape.Test) => {
+  const project = prepare(t)
+
+  await writeJsonFile('../is-positive/package.json', {name: 'is-positive', version: '1.0.0'})
+
+  await installPkgs(['is-positive@1.0.0'], await testDefaults())
+
+  t.ok(await exists('node_modules/.localhost+4873/is-positive/1.0.0/node_modules/is-positive/package.json'))
+
+  await link(['../is-positive'], path.resolve('node_modules'), await testDefaults())
+
+  t.notOk(await exists('node_modules/.localhost+4873/is-positive/1.0.0/node_modules/is-positive/package.json'), 'pruned')
 })

--- a/test/link.ts
+++ b/test/link.ts
@@ -29,7 +29,7 @@ test('relative link', async (t: tape.Test) => {
   const linkedPkgPath = path.resolve('..', linkedPkgName)
 
   await ncp(pathToLocalPkg(linkedPkgName), linkedPkgPath)
-  await link(`../${linkedPkgName}`, path.join(process.cwd(), 'node_modules'), await testDefaults())
+  await link([`../${linkedPkgName}`], path.join(process.cwd(), 'node_modules'), await testDefaults())
 
   await isExecutable(t, path.resolve('node_modules', '.bin', 'hello-world-js-bin'))
 
@@ -51,7 +51,7 @@ test('relative link is not rewritten by install', async (t: tape.Test) => {
   const linkedPkgPath = path.resolve('..', linkedPkgName)
 
   await ncp(pathToLocalPkg(linkedPkgName), linkedPkgPath)
-  await link(`../${linkedPkgName}`, path.join(process.cwd(), 'node_modules'), await testDefaults())
+  await link([`../${linkedPkgName}`], path.join(process.cwd(), 'node_modules'), await testDefaults())
 
   const reporter = sinon.spy()
 
@@ -99,7 +99,7 @@ test('global link', async function (t: tape.Test) {
 
   process.chdir(projectPath)
 
-  await linkFromGlobal(linkedPkgName, process.cwd(), await testDefaults({globalPrefix}))
+  await linkFromGlobal([linkedPkgName], process.cwd(), await testDefaults({globalPrefix}))
 
   isExecutable(t, path.resolve('node_modules', '.bin', 'hello-world-js-bin'))
 })
@@ -110,7 +110,7 @@ test('failed linking should not create empty folder', async (t: tape.Test) => {
   const globalPrefix = path.resolve('..', 'global')
 
   try {
-    await linkFromGlobal('does-not-exist', process.cwd(), await testDefaults({globalPrefix}))
+    await linkFromGlobal(['does-not-exist'], process.cwd(), await testDefaults({globalPrefix}))
     t.fail('should have failed')
   } catch (err) {
     t.notOk(await exists(path.join(globalPrefix, 'node_modules', 'does-not-exist')))

--- a/test/link.ts
+++ b/test/link.ts
@@ -23,7 +23,7 @@ import {
 import exists = require('path-exists')
 
 test('relative link', async (t: tape.Test) => {
-  prepare(t)
+  const project = prepare(t)
 
   const linkedPkgName = 'hello-world-js-bin'
   const linkedPkgPath = path.resolve('..', linkedPkgName)
@@ -36,6 +36,12 @@ test('relative link', async (t: tape.Test) => {
   // The linked package has been installed successfully as well with bins linked
   // to node_modules/.bin
   await isExecutable(t, path.join(linkedPkgPath, 'node_modules', '.bin', 'cowsay'))
+
+  const wantedShrinkwrap = await project.loadShrinkwrap()
+  t.equal(wantedShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link added to wanted shrinkwrap')
+
+  const currentShrinkwrap = await project.loadCurrentShrinkwrap()
+  t.equal(currentShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link added to wanted shrinkwrap')
 })
 
 test('relative link is not rewritten by install', async (t: tape.Test) => {
@@ -63,6 +69,12 @@ test('relative link is not rewritten by install', async (t: tape.Test) => {
       // TODO: the dependencyType should be `undefined` in this case
     },
   }), 'linked root dependency logged')
+
+  const wantedShrinkwrap = await project.loadShrinkwrap()
+  t.equal(wantedShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link still in wanted shrinkwrap')
+
+  const currentShrinkwrap = await project.loadCurrentShrinkwrap()
+  t.equal(currentShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link still in wanted shrinkwrap')
 })
 
 test('global link', async function (t: tape.Test) {

--- a/test/link.ts
+++ b/test/link.ts
@@ -23,7 +23,11 @@ import {
 import exists = require('path-exists')
 
 test('relative link', async (t: tape.Test) => {
-  const project = prepare(t)
+  const project = prepare(t, {
+    dependencies: {
+      'hello-world-js-bin': '*',
+    },
+  })
 
   const linkedPkgName = 'hello-world-js-bin'
   const linkedPkgPath = path.resolve('..', linkedPkgName)
@@ -39,6 +43,7 @@ test('relative link', async (t: tape.Test) => {
 
   const wantedShrinkwrap = await project.loadShrinkwrap()
   t.equal(wantedShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link added to wanted shrinkwrap')
+  t.equal(wantedShrinkwrap.specifiers['hello-world-js-bin'], '*', 'specifier of linked dependency added to shrinkwrap.yaml')
 
   const currentShrinkwrap = await project.loadCurrentShrinkwrap()
   t.equal(currentShrinkwrap.dependencies['hello-world-js-bin'], 'link:../hello-world-js-bin', 'link added to wanted shrinkwrap')

--- a/test/uninstall.ts
+++ b/test/uninstall.ts
@@ -154,7 +154,7 @@ test('relative link is uninstalled', async (t: tape.Test) => {
   const linkedPkgPath = path.resolve('..', linkedPkgName)
 
   await ncp(pathToLocalPkg(linkedPkgName), linkedPkgPath)
-  await link(`../${linkedPkgName}`, path.join(process.cwd(), 'node_modules'), await testDefaults())
+  await link([`../${linkedPkgName}`], path.join(process.cwd(), 'node_modules'), await testDefaults())
   await uninstall([linkedPkgName], await testDefaults())
 
   await project.hasNot(linkedPkgName)

--- a/test/unlink.ts
+++ b/test/unlink.ts
@@ -44,7 +44,7 @@ test('unlink 1 package that exists in package.json', async (t: tape.Test) => {
     }),
   ])
 
-  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), await testDefaults({prefix: path.resolve('project')}))
 
   process.chdir('project')
   await unlinkPkgs(['is-subdir'], await testDefaults())
@@ -57,7 +57,8 @@ test("don't update package when unlinking", async (t: tape.Test) => {
   const project = prepare(t)
 
   await addDistTag('foo', '100.0.0', 'latest')
-  await installPkgs(['foo'], await testDefaults())
+  const opts = await testDefaults({prefix: process.cwd()})
+  await installPkgs(['foo'], opts)
 
   process.chdir('..')
 
@@ -66,11 +67,11 @@ test("don't update package when unlinking", async (t: tape.Test) => {
     version: '100.0.0',
   })
 
-  await link(['foo'], path.join('project', 'node_modules'), await testDefaults())
+  await link(['foo'], path.join('project', 'node_modules'), opts)
   await addDistTag('foo', '100.1.0', 'latest')
 
   process.chdir('project')
-  await unlinkPkgs(['foo'], await testDefaults())
+  await unlinkPkgs(['foo'], opts)
 
   t.equal(project.requireModule('foo/package.json').version, '100.0.0', 'foo not updated after unlink')
 })
@@ -82,6 +83,7 @@ test("don't update package when unlinking. Initial link is done on a package w/o
     },
   })
 
+  const opts = await testDefaults({prefix: process.cwd()})
   process.chdir('..')
 
   await writeJsonFile('foo/package.json', {
@@ -89,11 +91,11 @@ test("don't update package when unlinking. Initial link is done on a package w/o
     version: '100.0.0',
   })
 
-  await link(['foo'], path.join('project', 'node_modules'), await testDefaults())
+  await link(['foo'], path.join('project', 'node_modules'), opts)
   await addDistTag('foo', '100.1.0', 'latest')
 
   process.chdir('project')
-  await unlinkPkgs(['foo'], await testDefaults())
+  await unlinkPkgs(['foo'], opts)
 
   t.equal(project.requireModule('foo/package.json').version, '100.1.0', 'latest foo is installed')
   t.deepEqual((await loadJsonFile('./package.json')).dependencies, {foo: '^100.0.0'}, 'package.json not updated')
@@ -105,6 +107,7 @@ test('unlink 2 packages. One of them exists in package.json', async (t: tape.Tes
       'is-subdir': '^1.0.0',
     }
   })
+  const opts = await testDefaults({prefix: process.cwd()})
   process.chdir('..')
 
   await Promise.all([
@@ -121,10 +124,10 @@ test('unlink 2 packages. One of them exists in package.json', async (t: tape.Tes
     }),
   ])
 
-  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), opts)
 
   process.chdir('project')
-  await unlinkPkgs(['is-subdir', 'is-positive'], await testDefaults())
+  await unlinkPkgs(['is-subdir', 'is-positive'], opts)
 
   t.equal(typeof project.requireModule('is-subdir'), 'function', 'is-subdir installed after unlinked')
   t.notOk(await exists(path.join('node_modules', 'is-positive')), 'is-positive removed as it is not in package.json')
@@ -137,6 +140,7 @@ test('unlink all packages', async (t: tape.Test) => {
       '@zkochan/logger': '^0.1.0',
     }
   })
+  const opts = await testDefaults({prefix: process.cwd()})
   process.chdir('..')
 
   await Promise.all([
@@ -153,10 +157,9 @@ test('unlink all packages', async (t: tape.Test) => {
     }),
   ])
 
-  await link(['is-subdir', 'logger'], path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'logger'], path.join('project', 'node_modules'), opts)
 
-  process.chdir('project')
-  await unlink(await testDefaults())
+  await unlink(opts)
 
   t.equal(typeof project.requireModule('is-subdir'), 'function', 'is-subdir installed after unlinked')
   t.equal(typeof project.requireModule('@zkochan/logger'), 'object', '@zkochan/logger installed after unlinked')

--- a/test/unlink.ts
+++ b/test/unlink.ts
@@ -44,8 +44,7 @@ test('unlink 1 package that exists in package.json', async (t: tape.Test) => {
     }),
   ])
 
-  await link('is-subdir', path.join('project', 'node_modules'), await testDefaults())
-  await link('is-positive', path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), await testDefaults())
 
   process.chdir('project')
   await unlinkPkgs(['is-subdir'], await testDefaults())
@@ -67,7 +66,7 @@ test("don't update package when unlinking", async (t: tape.Test) => {
     version: '100.0.0',
   })
 
-  await link('foo', path.join('project', 'node_modules'), await testDefaults())
+  await link(['foo'], path.join('project', 'node_modules'), await testDefaults())
   await addDistTag('foo', '100.1.0', 'latest')
 
   process.chdir('project')
@@ -90,7 +89,7 @@ test("don't update package when unlinking. Initial link is done on a package w/o
     version: '100.0.0',
   })
 
-  await link('foo', path.join('project', 'node_modules'), await testDefaults())
+  await link(['foo'], path.join('project', 'node_modules'), await testDefaults())
   await addDistTag('foo', '100.1.0', 'latest')
 
   process.chdir('project')
@@ -122,8 +121,7 @@ test('unlink 2 packages. One of them exists in package.json', async (t: tape.Tes
     }),
   ])
 
-  await link('is-subdir', path.join('project', 'node_modules'), await testDefaults())
-  await link('is-positive', path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'is-positive'], path.join('project', 'node_modules'), await testDefaults())
 
   process.chdir('project')
   await unlinkPkgs(['is-subdir', 'is-positive'], await testDefaults())
@@ -155,8 +153,7 @@ test('unlink all packages', async (t: tape.Test) => {
     }),
   ])
 
-  await link('is-subdir', path.join('project', 'node_modules'), await testDefaults())
-  await link('logger', path.join('project', 'node_modules'), await testDefaults())
+  await link(['is-subdir', 'logger'], path.join('project', 'node_modules'), await testDefaults())
 
   process.chdir('project')
   await unlink(await testDefaults())


### PR DESCRIPTION
We need info about linked packages to make `pnpm recursive` commands more deterministic. With this changes, when packages are linked in, the `shrinkwrap.yaml` file of the target package is updated. For example, foo is linked into bar, shrinkwrap.yaml of bar will be:

```yaml
dependencies:
  foo: link:../foo
registry: 'https://registry.npmjs.org/'
shrinkwrapMinorVersion: 4
shrinkwrapVersion: 3
specifiers: {}
```

TODO:

- [x] the link function should link several packages to minimize the number of operations on the shrinkwrap
- [x] `node_modules` has to be pruned after linking
- [x] ~don't run the `link()` function after installation~